### PR TITLE
Context api to provide access to robots and robots setter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,22 @@
-import { useState } from "react";
 import { CommandLine } from "./components/CommandLine/CommandLine";
 import Grid from "./components/Grid/Grid";
-import {
-  INITIAL_POSITION,
-  INITIAL_POSITION_2,
-  INITIAL_POSITION_3,
-} from "./constants/constants";
-import type { Robot } from "./types/types";
+import { RobotsProvider } from "./context/RobotsContext";
 
 function App() {
-  const [robots, setRobots] = useState<Robot[]>([
-    INITIAL_POSITION,
-    INITIAL_POSITION_2,
-    INITIAL_POSITION_3,
-  ]);
-
   return (
-    <div
-      className={
-        "font-roboto px-8  flex flex-col justify-center items-center mt-20"
-      }
-    >
-      <h1 className="text-center text-4xl font-bold">
-        A little stroll on Mars
-      </h1>
-      <Grid robots={robots} />
-      <CommandLine setRobotPosition={setRobots} robotPosition={robots} />
-    </div>
+    <RobotsProvider>
+      <div
+        className={
+          "font-roboto px-8  flex flex-col justify-center items-center mt-20"
+        }
+      >
+        <h1 className="text-center text-4xl font-bold">
+          A little stroll on Mars
+        </h1>
+        <Grid />
+        <CommandLine />
+      </div>
+    </RobotsProvider>
   );
 }
 

--- a/src/components/CommandLine/CommandLine.tsx
+++ b/src/components/CommandLine/CommandLine.tsx
@@ -5,7 +5,6 @@ import {
   INITIAL_POSITION_3,
   TRANSITION_SECONDS,
 } from "../../constants/constants";
-import type { Robot } from "../../types/types";
 import { Button } from "./Button";
 import { InstructionsInput } from "./InstructionsInput";
 import {
@@ -15,22 +14,20 @@ import {
 import { animationDuration } from "../../utils/animation-duration";
 import { moveForward } from "../../utils/move-forward";
 import { rotate } from "../../utils/rotate";
+import { useRobots } from "../../context/RobotsContext";
 
-export type CommandLineProps = {
-  setRobotPosition: React.Dispatch<React.SetStateAction<Robot[]>>;
-  robotPosition: Robot[];
-};
-
-export const CommandLine = ({ setRobotPosition }: CommandLineProps) => {
+export const CommandLine = () => {
   const [instructions, setInstructions] = useState("");
   const [isAnimating, setIsAnimating] = useState(false);
+  const context = useRobots();
+  const { setRobots } = context;
 
   const executeInstructions = async (instructions: string) => {
     setIsAnimating(true);
     for (const instruction of instructions) {
       await animationDuration(TRANSITION_SECONDS).then(() => {
         if (isMoveForwardInstruction(instruction)) {
-          setRobotPosition((prevPosition) => {
+          setRobots((prevPosition) => {
             const newPositions = prevPosition.map((pos) => moveForward(pos));
 
             return newPositions;
@@ -38,7 +35,7 @@ export const CommandLine = ({ setRobotPosition }: CommandLineProps) => {
         }
 
         if (isRotateInstruction(instruction)) {
-          setRobotPosition((prevPosition) => {
+          setRobots((prevPosition) => {
             const newPositions = prevPosition.map((pos) => {
               return {
                 ...pos,
@@ -71,11 +68,7 @@ export const CommandLine = ({ setRobotPosition }: CommandLineProps) => {
       </Button>
       <Button
         onClick={() =>
-          setRobotPosition([
-            INITIAL_POSITION,
-            INITIAL_POSITION_2,
-            INITIAL_POSITION_3,
-          ])
+          setRobots([INITIAL_POSITION, INITIAL_POSITION_2, INITIAL_POSITION_3])
         }
         disabled={isAnimating}
       >

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -3,14 +3,17 @@ import type { Robot } from "../../types/types";
 import { createArray } from "../../utils/create-array";
 import { getCoordinates } from "../../utils/get-coordinates";
 import { Cell } from "../Cell/Cell";
+import { useRobots } from "../../context/RobotsContext";
 
 export type GridProps = {
   robots: Robot[];
 };
 
-const Grid = ({ robots }: GridProps) => {
+const Grid = () => {
   const rowIndices = createArray(NUMBER_OF_ROWS);
   const columnIndices = createArray(NUMBER_OF_COLUMNS);
+  const context = useRobots();
+  const { robots } = context;
 
   return (
     <div

--- a/src/context/RobotsContext.tsx
+++ b/src/context/RobotsContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState } from "react";
+import { Robot } from "../types/types";
+import {
+  INITIAL_POSITION,
+  INITIAL_POSITION_2,
+  INITIAL_POSITION_3,
+} from "../constants/constants";
+
+type RobotsContext = {
+  robots: Robot[];
+  setRobots: React.Dispatch<React.SetStateAction<Robot[]>>;
+};
+
+export const RobotsContext = createContext<RobotsContext | undefined>(
+  undefined
+);
+
+export const RobotsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [robots, setRobots] = useState<Robot[]>([
+    INITIAL_POSITION,
+    INITIAL_POSITION_2,
+    INITIAL_POSITION_3,
+  ]);
+  return (
+    <RobotsContext.Provider value={{ robots, setRobots }}>
+      {children}
+    </RobotsContext.Provider>
+  );
+};
+
+export const useRobots = () => {
+  const context = useContext(RobotsContext);
+  if (!context) {
+    throw new Error("use robots needs a RobotsProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
Provides context to use `robots` and `setRobots`.

`Context` created in` context/RobotsContext.tsx` with:
`RobotsContext` type including the array of Robots and the setter function.
`RobotsContext` from `createContext` that is initialised to undefined.

`RobotsProvider` that will provide `[robots, setRobots]` to the children elements once wrapping them in `App.tsx`.
```
export const RobotsProvider = ({ children }: { children: React.ReactNode }) => {
  const [robots, setRobots] = useState<Robot[]>([
    INITIAL_POSITION,
    INITIAL_POSITION_2,
    INITIAL_POSITION_3,
  ]);
  return (
    <RobotsContext.Provider value={{ robots, setRobots }}>
      {children}
    </RobotsContext.Provider>
  );
};
```

`useRobots` hook to provide the context once used in the components.

For example:
```
  const context = useRobots();
  const { robots, setRobots } = context;
```
